### PR TITLE
Clarify missing email behaviour in backend

### DIFF
--- a/backend/poastal.py
+++ b/backend/poastal.py
@@ -86,7 +86,11 @@ def poastal():
             }
         })
     else:
-        return 'No email address provided.'
+        return jsonify({
+            'error': 'No email address provided.',
+            'usage': 'Send a GET request to this endpoint with the email query parameter.',
+            'placeholder': '/?email=example@gmail.com'
+        }), 400
 
 if __name__ == '__main__':
     app.run(port=8080, debug=True)


### PR DESCRIPTION
## Summary
- return a structured JSON error response when the email query parameter is missing
- include an example placeholder so users know how to supply the email value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe365a7f8832a85c11c402db4570d